### PR TITLE
ifcfg/parser: fix failure if ifconfig is not in $PATH

### DIFF
--- a/ifcfg/parser.py
+++ b/ifcfg/parser.py
@@ -1,4 +1,5 @@
 
+import os
 import re
 import socket
     
@@ -9,7 +10,12 @@ Log = minimal_logger(__name__)
 
 class IfcfgParser(MetaMixin):
     class Meta:
-        ifconfig_cmd_args = ['ifconfig', '-a']
+        ifconfig_cmd = 'ifconfig'
+        for path in ['/sbin','/usr/sbin','/bin','/usr/bin']:
+            if os.path.exists(os.path.join(path, ifconfig_cmd)):
+                ifconfig_cmd = os.path.join(path, ifconfig_cmd)
+                break
+        ifconfig_cmd_args = [ifconfig_cmd, '-a']
         patterns = [
             '(?P<device>^[a-zA-Z0-9]+): flags=(?P<flags>.*) mtu (?P<mtu>.*)',
             '.*(inet )(?P<inet>[^\s]*).*',


### PR DESCRIPTION
This module does not work if ifconfig is not in the user's $PATH.  Here is a patch to fix it.

``` python
>>> import ifcfg
>>> print ifcfg.interfaces()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/ifcfg-0.9.1-py2.7.egg/ifcfg/__init__.py", line 57, in interfaces
    parser = get_parser()
  File "/usr/local/lib/python2.7/dist-packages/ifcfg-0.9.1-py2.7.egg/ifcfg/__init__.py", line 41, in get_parser
    parser = LinuxParser(ifconfig=ifconfig)
  File "/usr/local/lib/python2.7/dist-packages/ifcfg-0.9.1-py2.7.egg/ifcfg/parser.py", line 160, in __init__
    super(Linux2Parser, self).__init__(*args, **kw)
  File "/usr/local/lib/python2.7/dist-packages/ifcfg-0.9.1-py2.7.egg/ifcfg/parser.py", line 153, in __init__
    super(LinuxParser, self).__init__(*args, **kw)
  File "/usr/local/lib/python2.7/dist-packages/ifcfg-0.9.1-py2.7.egg/ifcfg/parser.py", line 135, in __init__
    super(UnixParser, self).__init__(*args, **kw)
  File "/usr/local/lib/python2.7/dist-packages/ifcfg-0.9.1-py2.7.egg/ifcfg/parser.py", line 30, in __init__
    self.parse(self.ifconfig_data)
  File "/usr/local/lib/python2.7/dist-packages/ifcfg-0.9.1-py2.7.egg/ifcfg/parser.py", line 48, in parse
    ifconfig, err, retcode = exec_cmd(self._meta.ifconfig_cmd_args)
  File "/usr/local/lib/python2.7/dist-packages/ifcfg-0.9.1-py2.7.egg/ifcfg/tools.py", line 20, in exec_cmd
    proc = Popen(cmd_args, stdout=PIPE, stderr=PIPE)
  File "/usr/lib/python2.7/subprocess.py", line 679, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1259, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```
