### PR TITLE
fix getting default interface in ubuntu 17.10

### DIFF
--- a/src/ifcfg/parser.py
+++ b/src/ifcfg/parser.py
@@ -234,17 +234,13 @@ class UnixParser(Parser):
             lines = out.splitlines()
         else:
             lines = route_output.split("\n")
-        iface = ""
+
         for line in lines[2:]:
-            if str(line.split(" ")[0]) == '0.0.0.0':
-                iface = str(line.split()[-1])
-                break
-
-        for interface in self.interfaces.keys():
-            if interface == iface:
-                return self.interfaces[interface]
-
-        return None
+            line = line.split()
+            if '0.0.0.0' in line and \
+               'UG' in line:
+                iface = line[-1]
+                return self.interfaces.get(iface, None)
 
     @property
     def default_interface(self):


### PR DESCRIPTION
Thanks for your library.

I have _default_interface() failed in Ubuntu 17.10 because the route output is not exactly as function expect.

I've made this code to simplify the matching of the route command line in order to get the default gateway easily.

In essence the line must contain '0.0.0.0' and 'UG' to indicate that is the default one.

Finally I made a more pythonic return value at the end. Please note that return None is not necessary at the end of the function.

