### PR TITLE
Fix windows encoding error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
     sha: a11d9314b22d8f8c7556443875b731ef05965464
     hooks:
@@ -8,13 +9,8 @@
     -   id: debug-statements
     -   id: end-of-file-fixer
 -   repo: git://github.com/FalconSocial/pre-commit-python-sorter
-    sha: 5991d2aea26858d3c3538e0b4e09255b6b99413e
+    sha: b57843b0b874df1d16eb0bef00b868792cb245c2
     hooks:
     -   id: python-import-sorter
         args:
         - --silent-overwrite
--   repo: git://github.com/pre-commit/mirrors-eslint
-    sha: v3.14.0
-    hooks:
-    -   id: eslint
-        additional_dependencies: [ 'eslint', 'eslint-plugin-html', 'eslint-config-airbnb', 'eslint-plugin-import', 'eslint-plugin-jsx-a11y']

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,18 @@
-sudo: false
 dist: trusty
-
-env: PIP_DOWNLOAD_CACHE="pip_cache"
 
 language: python
 
-addons:
-  apt:
-    sources:
-      - deadsnakes
-    packages:
-      - python3.5
-      - python3.5-dev
-
-
-# See tox.ini for env list
-env:
-- TOXENV=py27
-- TOXENV=py34
-- TOXENV=py35
-- TOXENV=lint
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
 
 install:
-  - pip install -U pip codecov tox
+  - pip install -U pip codecov tox tox-travis
 
 script:
-  - tox -e $TOXENV
+  - tox
 
 after_success:
   - codecov

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,12 @@ following:
 Release notes
 -------------
 
+0.12
+____
+
+* Fix encoding crashes on non-English Windows systems
+
+
 0.11
 ____
 

--- a/src/ifcfg/__init__.py
+++ b/src/ifcfg/__init__.py
@@ -6,7 +6,7 @@ import platform
 from . import tools
 from . import parser
 
-__version__ = "0.11"
+__version__ = "0.12"
 
 Log = tools.minimal_logger(__name__)
 

--- a/tests/ipconfig_tests.py
+++ b/tests/ipconfig_tests.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import subprocess
+
 import ifcfg
+import mock
+from ifcfg import tools
 from ifcfg.parser import WindowsParser
 from nose.tools import eq_, ok_
 
@@ -70,8 +74,6 @@ class WindowsTestCase(IfcfgTestCase):
         eq_(interfaces['Ethernet adapter Ethernet 2']['ether'], '08:00:27:0d:9a:0b')
         eq_(interfaces['Ethernet adapter Ethernet 2']['inet6'], [])
 
-
-
     def test_windows7vm(self):
         ifcfg.distro = "Windows"
         ifcfg.Parser = ifcfg.get_parser_class()
@@ -79,6 +81,34 @@ class WindowsTestCase(IfcfgTestCase):
         self.assertTrue(issubclass(ifcfg.Parser, WindowsParser))
 
         parser = ifcfg.get_parser(ifconfig=ipconfig_out.WINDOWS_7_VM)
+        interfaces = parser.interfaces
+
+        self.assertIn("Ethernet adapter Local Area Connection 2", interfaces.keys())
+        self.assertIn("Tunnel adapter isatap.lan", interfaces.keys())
+        self.assertIn("Tunnel adapter Teredo Tunneling Pseudo-Interface", interfaces.keys())
+
+        self.assertEqual(len(interfaces.keys()), 3)
+
+        eq_(interfaces['Ethernet adapter Local Area Connection 2']['inet'], '10.0.2.15')
+        self.assertEqual(
+            len(interfaces['Ethernet adapter Local Area Connection 2']['inet6']),
+            0
+        )
+
+    # Add a character that's known to fail in cp1252 encoding
+    @mock.patch.object(subprocess.Popen, 'communicate', lambda __: [ipconfig_out.WINDOWS_7_VM + " \x81", ""])
+    @mock.patch.object(tools, 'system_encoding', "cp1252")
+    def test_cp1252_encoding(self):
+        """
+        Tests that things are still working when using this bizarre encoding
+        """
+
+        ifcfg.distro = "Windows"
+        ifcfg.Parser = ifcfg.get_parser_class()
+
+        self.assertTrue(issubclass(ifcfg.Parser, WindowsParser))
+
+        parser = ifcfg.get_parser()
         interfaces = parser.interfaces
 
         self.assertIn("Ethernet adapter Local Area Connection 2", interfaces.keys())

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ usedevelop = True
 deps =
      coverage
      nose
+     mock
 
 [testenv:lint]
 basepython = python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,13 @@
 [tox]
 # Ensure you add to .travis.yml if you add here, using `tox -l`
-envlist = py27,py34,py35,lint
+envlist = py27,py34,py35,py36,lint
+
+[travis]
+python =
+  2.7: py27,lint
+  3.4: py34
+  3.5: py35
+  3.6: py36
 
 [testenv]
 
@@ -8,6 +15,7 @@ basepython =
      py27: python2.7
      py34: python3.4
      py35: python3.5
+     py36: python3.6
 
 commands =
     python --version


### PR DESCRIPTION
Fixes an issue reported here:

https://github.com/learningequality/kolibri/issues/2994

I would like to assert some stuff regarding output of `ipconfig` on non-English Windows systems before the next release. If the encoding error is fixed but the parsing remains broken, there's still some work to be done...