### PR TITLE
Fixes encoding based on advice from @ftao

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,13 @@ following:
 Release notes
 -------------
 
+0.13
+____
+
+* Further crashes on non-English Windows systems
+* Known issue that localized Windows does not work: #81
+
+
 0.12
 ____
 

--- a/src/ifcfg/__init__.py
+++ b/src/ifcfg/__init__.py
@@ -6,7 +6,7 @@ import platform
 from . import tools
 from . import parser
 
-__version__ = "0.12"
+__version__ = "0.13"
 
 Log = tools.minimal_logger(__name__)
 

--- a/src/ifcfg/parser.py
+++ b/src/ifcfg/parser.py
@@ -249,6 +249,7 @@ class UnixParser(Parser):
         """
         return self._default_interface()
 
+
 class LinuxParser(UnixParser):
 
     @classmethod

--- a/tests/ipconfig_tests.py
+++ b/tests/ipconfig_tests.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import binascii
 import subprocess
 
 import ifcfg
@@ -96,9 +97,39 @@ class WindowsTestCase(IfcfgTestCase):
         )
 
     # Add a character that's known to fail in cp1252 encoding
-    @mock.patch.object(subprocess.Popen, 'communicate', lambda __: [ipconfig_out.WINDOWS_7_VM + " \x81", ""])
+    @mock.patch.object(subprocess.Popen, 'communicate', lambda __: [ipconfig_out.WINDOWS_7_VM.encode('cp1252') + binascii.unhexlify("81"), "".encode('cp1252')])
     @mock.patch.object(tools, 'system_encoding', "cp1252")
     def test_cp1252_encoding(self):
+        """
+        Tests that things are still working when using this bizarre encoding
+        """
+
+        ifcfg.distro = "Windows"
+        ifcfg.Parser = ifcfg.get_parser_class()
+
+        self.assertTrue(issubclass(ifcfg.Parser, WindowsParser))
+
+        parser = ifcfg.get_parser()
+        interfaces = parser.interfaces
+
+        self.assertIn("Ethernet adapter Local Area Connection 2", interfaces.keys())
+        self.assertIn("Tunnel adapter isatap.lan", interfaces.keys())
+        self.assertIn("Tunnel adapter Teredo Tunneling Pseudo-Interface", interfaces.keys())
+
+        self.assertEqual(len(interfaces.keys()), 3)
+
+        eq_(interfaces['Ethernet adapter Local Area Connection 2']['inet'], '10.0.2.15')
+        self.assertEqual(
+            len(interfaces['Ethernet adapter Local Area Connection 2']['inet6']),
+            0
+        )
+
+
+    # Add a character that's known to fail in unicode encoding
+    # https://github.com/ftao/python-ifcfg/issues/17
+    @mock.patch.object(subprocess.Popen, 'communicate', lambda __: [ipconfig_out.WINDOWS_7_VM.encode('cp1252') + binascii.unhexlify("84"), "".encode('cp1252')])
+    @mock.patch.object(tools, 'system_encoding', "cp1252")
+    def test_cp1252_non_utf8_byte(self):
         """
         Tests that things are still working when using this bizarre encoding
         """


### PR DESCRIPTION
I hope this does the trick.

The unfortunate issue is that it seems quite likely that using `ipconfig` for localized Windows isn't the way forward, but regardless, it's nice to have functional subprocess output and a non-crashing API :)

https://github.com/ftao/python-ifcfg/issues/17