### PR TITLE
Handle detecting docker bridge interfaces

### DIFF
--- a/src/ifcfg/parser.py
+++ b/src/ifcfg/parser.py
@@ -209,7 +209,7 @@ class UnixParser(Parser):
     @classmethod
     def get_patterns(cls):
         return [
-            '(?P<device>^[a-zA-Z0-9:]+): flags=(?P<flags>.*) mtu (?P<mtu>.*)',
+            '(?P<device>^[-a-zA-Z0-9:]+): flags=(?P<flags>.*) mtu (?P<mtu>.*)',
             '.*inet\s+(?P<inet>[\d\.]+).*',
             '.*inet6\s+(?P<inet6>[\d\:abcdef]+).*',
             '.*broadcast (?P<broadcast>[^\s]*).*',

--- a/tests/ifconfig_out.py
+++ b/tests/ifconfig_out.py
@@ -118,17 +118,17 @@ eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
 
 MACOSX = """
 en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
-  options=2b<RXCSUM,TXCSUM,VLAN_HWTAGGING,TSO4>
-  ether 1a:2b:3c:4d:5e:6f
-  inet6 fe80::4240:36ff:fe38:a121%en0 prefixlen 64 scopeid 0x5
-  inet 192.168.0.1 netmask 0xffffff00 broadcast 192.168.0.255
-  media: autoselect (100baseTX <full-duplex>)
-  status: active
+    options=2b<RXCSUM,TXCSUM,VLAN_HWTAGGING,TSO4>
+    ether 1a:2b:3c:4d:5e:6f
+    inet6 fe80::4240:36ff:fe38:a121%en0 prefixlen 64 scopeid 0x5
+    inet 192.168.0.1 netmask 0xffffff00 broadcast 192.168.0.255
+    media: autoselect (100baseTX <full-duplex>)
+    status: active
 lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
-  options=3<RXCSUM,TXCSUM>
-  inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1
-  inet 127.0.0.1 netmask 0xff000000
-  inet6 ::1 prefixlen 128
+    options=3<RXCSUM,TXCSUM>
+    inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1
+    inet 127.0.0.1 netmask 0xff000000
+    inet6 ::1 prefixlen 128
 """  # noqa
 
 

--- a/tests/ifconfig_out.py
+++ b/tests/ifconfig_out.py
@@ -42,6 +42,70 @@ lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 16436
         TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
 """
 
+LINUXDOCKER = """
+br-736aa253dd57: flags=4099<UP,BROADCAST,MULTICAST>  mtu 1500
+        inet 172.19.0.1  netmask 255.255.0.0  broadcast 0.0.0.0
+        inet6 fe80::42:9cff:fefe:60db  prefixlen 64  scopeid 0x20<link>
+        ether 02:42:9c:fe:60:db  txqueuelen 0  (Ethernet)
+        RX packets 120327  bytes 1571313930 (1.5 GB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 121053  bytes 23186380 (23.1 MB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+br-c4d6dd0473e5: flags=4099<UP,BROADCAST,MULTICAST>  mtu 1500
+        inet 172.18.0.1  netmask 255.255.0.0  broadcast 0.0.0.0
+        ether 02:42:a4:85:da:bd  txqueuelen 0  (Ethernet)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 0  bytes 0 (0.0 B)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+br-c75cf3b1db15: flags=4099<UP,BROADCAST,MULTICAST>  mtu 1500
+        inet 172.20.0.1  netmask 255.255.0.0  broadcast 0.0.0.0
+        ether 02:42:97:dd:9a:dd  txqueuelen 0  (Ethernet)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 0  bytes 0 (0.0 B)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+docker0: flags=4099<UP,BROADCAST,MULTICAST>  mtu 1500
+        inet 172.17.0.1  netmask 255.255.0.0  broadcast 0.0.0.0
+        ether 02:42:2a:ec:97:79  txqueuelen 0  (Ethernet)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 0  bytes 0 (0.0 B)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+enp0s31f6: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+        inet 192.168.1.94  netmask 255.255.255.0  broadcast 192.168.1.255
+        inet6 2a01:cb19:810a:da00:59d7:a6e1:8596:12f3  prefixlen 64  scopeid 0x0<global>
+        inet6 2a01:cb19:810a:da00:1e2b:9b33:6f04:df10  prefixlen 64  scopeid 0x0<global>
+        inet6 fe80::1487:95e4:d852:11aa  prefixlen 64  scopeid 0x20<link>
+        ether 54:e1:ad:76:c8:cb  txqueuelen 1000  (Ethernet)
+        RX packets 37234442  bytes 45411193577 (45.4 GB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 17430466  bytes 12618211757 (12.6 GB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+        device interrupt 16  memory 0xec200000-ec220000
+
+lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
+        inet 127.0.0.1  netmask 255.0.0.0
+        inet6 ::1  prefixlen 128  scopeid 0x10<host>
+        loop  txqueuelen 1000  (Local Loopback)
+        RX packets 2385680  bytes 1832529401 (1.8 GB)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 2385680  bytes 1832529401 (1.8 GB)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+
+virbr0: flags=4099<UP,BROADCAST,MULTICAST>  mtu 1500
+        inet 192.168.122.1  netmask 255.255.255.0  broadcast 192.168.122.255
+        ether 52:54:00:e2:85:a9  txqueuelen 1000  (Ethernet)
+        RX packets 0  bytes 0 (0.0 B)
+        RX errors 0  dropped 0  overruns 0  frame 0
+        TX packets 0  bytes 0 (0.0 B)
+        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
+"""
+
 LINUX = LINUX3
 
 
@@ -54,17 +118,17 @@ eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
 
 MACOSX = """
 en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
-	options=2b<RXCSUM,TXCSUM,VLAN_HWTAGGING,TSO4>
-	ether 1a:2b:3c:4d:5e:6f
-	inet6 fe80::4240:36ff:fe38:a121%en0 prefixlen 64 scopeid 0x5
-	inet 192.168.0.1 netmask 0xffffff00 broadcast 192.168.0.255
-	media: autoselect (100baseTX <full-duplex>)
-	status: active
+  options=2b<RXCSUM,TXCSUM,VLAN_HWTAGGING,TSO4>
+  ether 1a:2b:3c:4d:5e:6f
+  inet6 fe80::4240:36ff:fe38:a121%en0 prefixlen 64 scopeid 0x5
+  inet 192.168.0.1 netmask 0xffffff00 broadcast 192.168.0.255
+  media: autoselect (100baseTX <full-duplex>)
+  status: active
 lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
-	options=3<RXCSUM,TXCSUM>
-	inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1
-	inet 127.0.0.1 netmask 0xff000000
-	inet6 ::1 prefixlen 128
+  options=3<RXCSUM,TXCSUM>
+  inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1
+  inet 127.0.0.1 netmask 0xff000000
+  inet6 ::1 prefixlen 128
 """  # noqa
 
 

--- a/tests/ifconfig_tests.py
+++ b/tests/ifconfig_tests.py
@@ -62,6 +62,21 @@ class IfcfgTestCase(IfcfgTestCase):
         eq_(interfaces['eth0']['broadcast'], '192.168.0.255')
         eq_(interfaces['eth0']['netmask'], '255.255.255.0')
 
+    def test_linuxdocker(self):
+        ifcfg.distro = 'Linux'
+        ifcfg.Parser = ifcfg.get_parser_class()
+        parser = ifcfg.get_parser(ifconfig=ifconfig_out.LINUXDOCKER)
+        interfaces = parser.interfaces
+        self.assertEqual(len(interfaces.keys()), 7)
+        eq_(interfaces['enp0s31f6']['ether'], '54:e1:ad:76:c8:cb')
+        eq_(interfaces['enp0s31f6']['inet'], '192.168.1.94')
+        eq_(interfaces['enp0s31f6']['broadcast'], '192.168.1.255')
+        eq_(interfaces['enp0s31f6']['netmask'], '255.255.255.0')
+        eq_(interfaces['br-736aa253dd57']['ether'], '02:42:9c:fe:60:db')
+        eq_(interfaces['br-736aa253dd57']['inet'], '172.19.0.1')
+        eq_(interfaces['br-736aa253dd57']['broadcast'], '0.0.0.0')
+        eq_(interfaces['br-736aa253dd57']['netmask'], '255.255.0.0')
+
     def test_macosx(self):
         ifcfg.distro = 'MacOSX'
         ifcfg.Parser = ifcfg.get_parser_class()


### PR DESCRIPTION
It seems that if there are any docker network bridge interfaces
present on Linux (Unix?) machine (tested on Ubuntu 17.10), it makes
ifcfg crash while detecting devices due to the different naming
pattern.

As described here:
https://github.com/docker/labs/blob/master/networking/concepts/05-bridge-networks.md
docker creates network bridge interfaces with the following pattern,
e.g.: `br-4bcc22f5e5b9`, which fails to match on any currently given
regexp pattern.

This commit simply adds hypen to the `UnixParser`, `get_patterns`'s
first regexp pattern in order to catch interfaces with hypens as well.

As far as the escaping of the hypen or its position within the pattern
goes, my understanding is that the both cases are "safe" (having it as
the first/last character in the group or escaping it with backlash).

Here's an SO question/answer which relates to a very similiar use case:
https://stackoverflow.com/questions/9589074/regex-should-hyphens-be-escaped/9589642#9589642

This change also includes a test for this particular case.