### PR TITLE
Feature:  Multiple inet4 address for a single interface

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,8 @@ Usage
     for name, interface in ifcfg.interfaces().items():
         # do something with interface
         print interface['device']
-        print interface['inet']
+        print interface['inet']         # First IPv4 found
+        print interface['inet4']        # List of ips
         print interface['inet6']
         print interface['netmask']
         print interface['broadcast']
@@ -43,6 +44,7 @@ following:
             "flags": "4163<up,broadcast,running,multicast> ",
             "hostname": "derks-vm.local",
             "inet": "172.16.217.10",
+            "inet4": ["172.16.217.10"],
             "inet6": ["fe80::20c:29ff:fe0c:da5d"],
             "mtu": "1500",
             "name": "eth0",
@@ -53,6 +55,7 @@ following:
             "flags": "73<up,loopback,running> ",
             "hostname": "localhost",
             "inet": "127.0.0.1",
+            "inet4": ["127.0.0.1"],
             "inet6": ["::1"],
             "mtu": "16436",
             "name": "lo",
@@ -64,6 +67,7 @@ following:
             "flags": "4099<up,broadcast,multicast> ",
             "hostname": "derks-vm.local",
             "inet": "192.168.122.1",
+            "inet4": ["192.168.122.1"],
             "inet6": [],
             "mtu": "1500",
             "name": "virbr0",
@@ -74,6 +78,8 @@ following:
 
 Release notes
 -------------
+
+* Support for multiple IPv4 addresses in the new 'inet4' field
 
 0.15
 ____

--- a/tests/ifconfig_out.py
+++ b/tests/ifconfig_out.py
@@ -132,6 +132,72 @@ lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
 """  # noqa
 
 
+MACOSX2 = """
+lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
+        options=1203<RXCSUM,TXCSUM,TXSTATUS,SW_TIMESTAMP>
+        inet 127.0.0.1 netmask 0xff000000
+        inet6 ::1 prefixlen 128
+        inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1
+        inet 127.0.1.99 netmask 0xff000000
+        nd6 options=201<PERFORMNUD,DAD>
+en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+        ether 8c:85:90:00:aa:bb
+        inet6 fe80::1c8b:e7cc:c695:a6de%en0 prefixlen 64 secured scopeid 0x6
+        inet 10.0.1.12 netmask 0xffff0000 broadcast 10.0.255.255
+        inet6 2601:980:c000:7c5a:da:6a59:1e94:b03 prefixlen 64 autoconf secured
+        inet6 2601:980:c000:7c5a:fdb3:b90c:80d6:abcd prefixlen 64 deprecated autoconf temporary
+        inet6 2601:980:c000:7c5a:34b0:676d:93f7:0123 prefixlen 64 autoconf temporary
+        nd6 options=201<PERFORMNUD,DAD>
+        media: autoselect
+        status: active
+en1: flags=963<UP,BROADCAST,SMART,RUNNING,PROMISC,SIMPLEX> mtu 1500
+        options=60<TSO4,TSO6>
+        ether 7a:00:48:a1:b2:00
+        media: autoselect <full-duplex>
+        status: inactive
+p2p0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> mtu 2304
+        ether 0e:85:90:0f:ab:cd
+        media: autoselect
+        status: inactive
+awdl0: flags=8943<UP,BROADCAST,RUNNING,PROMISC,SIMPLEX,MULTICAST> mtu 1484
+        ether 2e:51:48:37:99:0a
+        inet6 fe80::2c51:48ff:fe37:86f8%awdl0 prefixlen 64 scopeid 0xc
+        nd6 options=201<PERFORMNUD,DAD>
+        media: autoselect
+        status: active
+bridge0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+        options=63<RXCSUM,TXCSUM,TSO4,TSO6>
+        ether 7a:00:48:c8:aa:bd
+        Configuration:
+                id 0:0:0:0:0:0 priority 0 hellotime 0 fwddelay 0
+                maxage 0 holdcnt 0 proto stp maxaddr 100 timeout 1200
+                root id 0:0:0:0:0:0 priority 0 ifcost 0 port 0
+                ipfilter disabled flags 0x2
+        member: en1 flags=3<LEARNING,DISCOVER>
+                ifmaxaddr 0 port 7 priority 0 path cost 0
+        member: en2 flags=3<LEARNING,DISCOVER>
+                ifmaxaddr 0 port 8 priority 0 path cost 0
+        member: en3 flags=3<LEARNING,DISCOVER>
+                ifmaxaddr 0 port 9 priority 0 path cost 0
+        member: en4 flags=3<LEARNING,DISCOVER>
+                ifmaxaddr 0 port 10 priority 0 path cost 0
+        nd6 options=201<PERFORMNUD,DAD>
+        media: <unknown type>
+        status: inactive
+utun0: flags=8051<UP,POINTOPOINT,RUNNING,MULTICAST> mtu 2000
+        inet6 fe80::ebb7:7d4a:49e8:e4fc%utun0 prefixlen 64 scopeid 0xe
+        nd6 options=201<PERFORMNUD,DAD>
+vboxnet0: flags=8842<BROADCAST,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+        ether 0a:00:27:00:00:00
+en5: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+        ether ac:de:48:00:22:11
+        inet6 fe80::aede:48ff:fe00:2211%en5 prefixlen 64 scopeid 0x5
+        nd6 options=281<PERFORMNUD,INSECURE,DAD>
+        media: autoselect
+        status: active
+"""
+
+
 ROUTE_OUTPUT = """
 Kernel IP routing table
 Destination     Gateway         Genmask         Flags Metric Ref    Use Iface

--- a/tests/ifconfig_tests.py
+++ b/tests/ifconfig_tests.py
@@ -88,6 +88,16 @@ class IfcfgTestCase(IfcfgTestCase):
         eq_(interfaces['en0']['broadcast'], '192.168.0.255')
         eq_(interfaces['en0']['netmask'], '255.255.255.0')
 
+    def test_macosx2(self):
+        ifcfg.distro = 'MacOSX'
+        ifcfg.Parser = ifcfg.get_parser_class()
+        parser = ifcfg.get_parser(ifconfig=ifconfig_out.MACOSX2)
+        interfaces = parser.interfaces
+        self.assertEqual(len(interfaces.keys()), 9)
+        eq_(interfaces['lo0']['inet'], '127.0.0.1')
+        eq_(interfaces['lo0']['inet4'], ['127.0.0.1', '127.0.1.99'])
+        eq_(interfaces['lo0']['netmask'], '255.0.0.0')
+
     def test_default_interface(self):
         ifcfg.distro = 'Linux'
         ifcfg.Parser = ifcfg.get_parser_class()

--- a/tests/ip_out.py
+++ b/tests/ip_out.py
@@ -27,6 +27,18 @@ LINUX = """1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN g
     link/ether a0:00:00:00:00:00 brd ff:ff:ff:ff:ff:ff
 """
 
+LINUX_MULTI_IPV4 = """
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
+    link/ether b8:27:eb:50:39:69 brd ff:ff:ff:ff:ff:ff
+    inet 192.168.13.1/24 brd 192.168.13.255 scope global eth0
+       valid_lft forever preferred_lft forever
+    inet 192.168.10.3/24 scope global eth0
+       valid_lft forever preferred_lft forever
+    inet6 fe80::ba27:ebff:fe50:3969/64 scope link
+       valid_lft forever preferred_lft forever
+"""
+
+
 ROUTE_OUTPUT = """
 Kernel IP routing table
 Destination     Gateway         Genmask         Flags Metric Ref    Use Iface

--- a/tests/ip_tests.py
+++ b/tests/ip_tests.py
@@ -31,6 +31,17 @@ class IpTestCase(IfcfgTestCase):
         eq_(interfaces['wlp3s0']['broadcast'], '192.168.12.255')
         eq_(interfaces['wlp3s0']['netmask'], '/24')
 
+    def test_linux_multi_inet4(self):
+        ifcfg.Parser = UnixIPParser
+        parser = ifcfg.get_parser(ifconfig=ip_out.LINUX_MULTI_IPV4)
+        interfaces = parser.interfaces
+        # Connected interface
+        eq_(interfaces['eth0']['ether'], 'b8:27:eb:50:39:69')
+        eq_(interfaces['eth0']['inet'], '192.168.13.1')
+        eq_(interfaces['eth0']['inet4'], ['192.168.13.1', '192.168.10.3'])
+        eq_(interfaces['eth0']['broadcast'], '192.168.13.255')
+        eq_(interfaces['eth0']['netmask'], '/24')
+
     def test_default_interface(self):
         ifcfg.distro = 'Linux'
         ifcfg.Parser = UnixIPParser


### PR DESCRIPTION
This feature branch attempts to resolve #20

This patch adds a new output list called "inet4" which contains all IPv4 addresses listed.  The "inet" field is also still present, containing the first IPv4 address encountered.  (So for most users, they will see no difference.)

Two new unit tests were added:  one for linux and one for Mac OS X.

Known limitation:   In the situation where multiple inet4 addresses exist on the same interface using different netmasks an exception will still be thrown.  (I wasn't able to find an example test case for this.) 
 This isn't ideal, but it still supports more configurations then it did before without breaking backwards compatibility.