### PR TITLE
Extend device name pattern in UnixIPParser

### DIFF
--- a/src/ifcfg/parser.py
+++ b/src/ifcfg/parser.py
@@ -301,7 +301,7 @@ class UnixIPParser(UnixParser):
     @classmethod
     def get_patterns(cls):
         return [
-            '\s*[0-9]+:\s+(?P<device>[a-zA-Z0-9]+):.*mtu (?P<mtu>.*)',
+            '\s*[0-9]+:\s+(?P<device>[^:]+):.*mtu (?P<mtu>.*)',
             '.*(inet\s)(?P<inet4>[\d\.]+)',
             '.*(inet6 )(?P<inet6>[^/]*).*',
             '.*(ether )(?P<ether>[^\s]*).*',


### PR DESCRIPTION
Accept everything except colon when matching device name. Examples that
didn't match before:
    2: eth-int: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc
    7: eth-usb-5@eth-usb: <BROADCAST,MULTICAST> mtu 1500 qdisc noop