### PR TITLE
Do not include @ in parsed interface name and add a test for it.

### DIFF
--- a/src/ifcfg/parser.py
+++ b/src/ifcfg/parser.py
@@ -301,7 +301,7 @@ class UnixIPParser(UnixParser):
     @classmethod
     def get_patterns(cls):
         return [
-            '\s*[0-9]+:\s+(?P<device>[^:]+):.*mtu (?P<mtu>.*)',
+            r'\s*[0-9]+:\s+(?P<device>[^@:]+)[^:]*:.*mtu (?P<mtu>.*)',
             '.*(inet\s)(?P<inet4>[\d\.]+)',
             '.*(inet6 )(?P<inet6>[^/]*).*',
             '.*(ether )(?P<ether>[^\s]*).*',

--- a/tests/ip_out.py
+++ b/tests/ip_out.py
@@ -25,6 +25,12 @@ LINUX = """1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN g
        valid_lft forever preferred_lft forever
 6: wwp0s29u1u4i6: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
     link/ether a0:00:00:00:00:00 brd ff:ff:ff:ff:ff:ff
+8: enp6s0.2@enp6s0: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN group default qlen 1000
+    link/ether 00:73:00:5c:09:9a brd ff:ff:ff:ff:ff:ff
+    inet 10.2.2.253/24 scope global enp6s0.2
+       valid_lft forever preferred_lft forever
+    inet 10.1.1.253/24 scope global enp6s0.2
+       valid_lft forever preferred_lft forever
 """
 
 LINUX_MULTI_IPV4 = """

--- a/tests/ip_tests.py
+++ b/tests/ip_tests.py
@@ -28,8 +28,14 @@ class IpTestCase(IfcfgTestCase):
         # Connected interface
         eq_(interfaces['wlp3s0']['ether'], 'a0:00:00:00:00:00')
         eq_(interfaces['wlp3s0']['inet'], '192.168.12.34')
+        eq_(interfaces['wlp3s0']['inet6'], ['fd37:a521:ada9::869', 'fd37:a521:ada9:0:b9f7:44f8:bb19:c78c', 'fd37:a521:ada9:0:9073:a91:d14f:8087', 'fe80::205f:5d09:d0da:7aed'])
         eq_(interfaces['wlp3s0']['broadcast'], '192.168.12.255')
         eq_(interfaces['wlp3s0']['netmask'], '/24')
+        # Connected interface
+        eq_(interfaces['enp6s0.2']['ether'], '00:73:00:5c:09:9a')
+        eq_(interfaces['enp6s0.2']['inet'], '10.2.2.253')
+        eq_(interfaces['enp6s0.2']['inet4'], ['10.2.2.253', '10.1.1.253'])
+        eq_(interfaces['enp6s0.2']['inet6'], [])
 
     def test_linux_multi_inet4(self):
         ifcfg.Parser = UnixIPParser


### PR DESCRIPTION
Oops, looks like I missed one thing in #35: `ip a` returns interface name like `eth-usb-6@eth-usb`, but it cannot be used as is because the part after `@` denotes the parent. Updated the code to match name until the `@` and added a test.