### PR TITLE
Feature/raise on missing utils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ python:
   - "3.5"
   - "3.6"
 
+before_install:
+  - sudo apt-get install -y net-tools
+
 install:
   - pip install -U pip codecov tox tox-travis
 

--- a/src/ifcfg/__init__.py
+++ b/src/ifcfg/__init__.py
@@ -22,12 +22,12 @@ def get_parser_class():
     global distro
     if distro == 'Linux':
         Parser = parser.LinuxParser
-        if not os.path.exists(Parser.get_command()[0]):
+        if not os.path.exists(Parser.get_command().split(' ')[0]):
             Parser = parser.UnixIPParser
-            if not os.path.exists(Parser.get_command()[0]):
+            if not os.path.exists(Parser.get_command().split(' ')[0]):
                 Log.warning("Neither `ifconfig` (`%s`) nor `ip` (`%s`) commands are available, listing network interfaces is likely to fail",
-                            parser.LinuxParser.get_command()[0],
-                            parser.UnixIPParser.get_command()[0])
+                            parser.LinuxParser.get_command(),
+                            parser.UnixIPParser.get_command())
     elif distro in ['Darwin', 'MacOSX']:
         Parser = parser.MacOSXParser
     elif distro == 'Windows':

--- a/src/ifcfg/__init__.py
+++ b/src/ifcfg/__init__.py
@@ -25,7 +25,9 @@ def get_parser_class():
         if not os.path.exists(Parser.get_command()[0]):
             Parser = parser.UnixIPParser
             if not os.path.exists(Parser.get_command()[0]):
-                Log.warning("Neither `ifconfig` nor `ip` commands are available, listing network interfaces is likely to fail")
+                Log.warning("Neither `ifconfig` (`%s`) nor `ip` (`%s`) commands are available, listing network interfaces is likely to fail",
+                            parser.LinuxParser.get_command()[0],
+                            parser.UnixIPParser.get_command()[0])
     elif distro in ['Darwin', 'MacOSX']:
         Parser = parser.MacOSXParser
     elif distro == 'Windows':

--- a/src/ifcfg/__init__.py
+++ b/src/ifcfg/__init__.py
@@ -24,6 +24,8 @@ def get_parser_class():
         Parser = parser.LinuxParser
         if not os.path.exists(Parser.get_command()[0]):
             Parser = parser.UnixIPParser
+            if not os.path.exists(Parser.get_command()[0]):
+                Log.warning("Neither `ifconfig` nor `ip` commands are available, getting interfaces is likely to fail")
     elif distro in ['Darwin', 'MacOSX']:
         Parser = parser.MacOSXParser
     elif distro == 'Windows':

--- a/src/ifcfg/__init__.py
+++ b/src/ifcfg/__init__.py
@@ -25,7 +25,7 @@ def get_parser_class():
         if not os.path.exists(Parser.get_command()[0]):
             Parser = parser.UnixIPParser
             if not os.path.exists(Parser.get_command()[0]):
-                Log.warning("Neither `ifconfig` nor `ip` commands are available, getting interfaces is likely to fail")
+                Log.warning("Neither `ifconfig` nor `ip` commands are available, listing network interfaces is likely to fail")
     elif distro in ['Darwin', 'MacOSX']:
         Parser = parser.MacOSXParser
     elif distro == 'Windows':

--- a/src/ifcfg/parser.py
+++ b/src/ifcfg/parser.py
@@ -51,7 +51,10 @@ class Parser(object):
 
         """
         if not ifconfig:
-            ifconfig, __, __ = exec_cmd(self.get_command())
+            ifconfig, errors, return_code = exec_cmd(self.get_command())
+            if return_code:
+                Log.error(errors)
+                raise ValueError("Non-zero return code, reporting error-code '{}'".format(errors))
         self.ifconfig_data = ifconfig
         cur = None
         patterns = self.get_patterns()

--- a/tests/ipconfig_tests.py
+++ b/tests/ipconfig_tests.py
@@ -97,6 +97,9 @@ class WindowsTestCase(IfcfgTestCase):
         )
 
     # Add a character that's known to fail in cp1252 encoding
+    # Patching `wait` is needed because on CI, these process (for Windows) don't really exist and cannot be executed
+    # `wait` sets the returncode which must be 0 for the parser to run
+    @mock.patch.object(subprocess.Popen, 'wait', lambda __: 0)
     @mock.patch.object(subprocess.Popen, 'communicate', lambda __: [ipconfig_out.WINDOWS_7_VM.encode('cp1252') + binascii.unhexlify("81"), "".encode('cp1252')])
     @mock.patch.object(tools, 'system_encoding', "cp1252")
     def test_cp1252_encoding(self):
@@ -124,9 +127,9 @@ class WindowsTestCase(IfcfgTestCase):
             0
         )
 
-
     # Add a character that's known to fail in unicode encoding
     # https://github.com/ftao/python-ifcfg/issues/17
+    @mock.patch.object(subprocess.Popen, 'wait', lambda __: 0)  # See test_cp1252_encoding's mocks as well
     @mock.patch.object(subprocess.Popen, 'communicate', lambda __: [ipconfig_out.WINDOWS_7_VM.encode('cp1252') + binascii.unhexlify("84"), "".encode('cp1252')])
     @mock.patch.object(tools, 'system_encoding', "cp1252")
     def test_cp1252_non_utf8_byte(self):


### PR DESCRIPTION
Fixes #44 
Output in case both `ifconfig` and `ip` are missing is this:
```
root@83317aab73fc:/python-ifcfg/src/ifcfg# python3 cli.py 
Neither `ifconfig` (`ifconfig -a`) nor `ip` (`ip address show`) commands are available, listing network interfaces is likely to fail
/bin/sh: 1: ip: not found

Traceback (most recent call last):
  File "cli.py", line 13, in <module>
    main()
  File "cli.py", line 9, in main
    print(json.dumps(ifcfg.interfaces(), indent=2))
  File "/python-ifcfg/src/ifcfg/__init__.py", line 70, in interfaces
    return Parser(ifconfig=ifconfig).interfaces
  File "/python-ifcfg/src/ifcfg/parser.py", line 30, in __init__
    self.parse(self.ifconfig_data)
  File "/python-ifcfg/src/ifcfg/parser.py", line 57, in parse
    raise ValueError("Non-zero return code, reporting error-code '{}'".format(errors))
ValueError: Non-zero return code, reporting error-code '/bin/sh: 1: ip: not found
'
```

First is a warning, raised when the module is imported and the exception is raised when getting `interfaces()`