### PR TITLE
force command to use C locale

### DIFF
--- a/src/ifcfg/tools.py
+++ b/src/ifcfg/tools.py
@@ -29,7 +29,9 @@ def exec_cmd(cmd_args):
     # errors of bytes that are invalid (happens on Windows)
     # NB! Python 2 returns a string, Python 3 returns a bytestring
     # https://github.com/ftao/python-ifcfg/issues/17
-    proc = Popen(cmd_args, stdout=PIPE, stderr=PIPE, universal_newlines=False, shell=True)
+    env = os.environ.copy()
+    env.update({"LANG": "C"})
+    proc = Popen(cmd_args, stdout=PIPE, stderr=PIPE, universal_newlines=False, shell=True, env=env)
     stdout, stderr = proc.communicate()
     proc.wait()
 


### PR DESCRIPTION
**I have _not_ tested this on windows, maybe there needs to be an additional check for that!**

So the problem I'm trying to fix here, is that if you system uses a non English locale the `LinuxParser` will not give the expected results because the regex does not match anymore:

```
# echo $LANG
de_DE.UTF-8
```

```
# ifconfig brlan
brlan     Link encap:Ethernet  Hardware Adresse 00:50:56:a1:45:0a  
          inet Adresse:172.16.10.15  Bcast:172.16.15.255  Maske:255.255.240.0
          inet6-Adresse: fe80::250:56ff:fea1:450a/64 Gültigkeitsbereich:Verbindung
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metrik:1
          RX packets:33399 errors:0 dropped:0 overruns:0 frame:0
          TX packets:10607 errors:0 dropped:0 overruns:0 carrier:0
          Kollisionen:0 Sendewarteschlangenlänge:1000 
          RX bytes:1732712 (1.6 MiB)  TX bytes:876186 (855.6 KiB)
```
```
# LANG=C ifconfig brlan
brlan     Link encap:Ethernet  HWaddr 00:50:56:a1:45:0a  
          inet addr:172.16.10.15  Bcast:172.16.15.255  Mask:255.255.240.0
          inet6 addr: fe80::250:56ff:fea1:450a/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:33409 errors:0 dropped:0 overruns:0 frame:0
          TX packets:10612 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:1733232 (1.6 MiB)  TX bytes:876616 (856.0 KiB)
```

Without this change:

```
Python 3.7.6 (default, Feb  5 2020, 15:49:29) 
[GCC 4.9.2] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import ifcfg
>>> ifcfg.interfaces().get("brlan")
{'inet': None, 'inet4': [], 'ether': None, 'inet6': [], 'netmask': None, 'device': 'brlan', 'broadcast': '172.16.15.255', 'mtu': '1500', 'rxbytes': '1734110', 'txbytes': '877304'}
>>>
```

With this change:

```
Python 3.7.6 (default, Feb  5 2020, 15:49:29) 
[GCC 4.9.2] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import ifcfg
>>> ifcfg.interfaces().get("brlan")
{'inet': '172.16.10.15', 'inet4': ['172.16.10.15'], 'ether': '00:50:56:a1:45:0a', 'inet6': ['add', 'fe80::250:56ff:fea1:450a'], 'netmask': '255.255.240.0', 'device': 'brlan', 'broadcast': '172.16.15.255', 'mtu': '1500', 'rxbytes': '1734526', 'txbytes': '877718'}
```