### PR TITLE
Add support for multiple netmasks, broadcast addresses, as well as ipv6 prefix lengths

### DIFF
--- a/src/ifcfg/parser.py
+++ b/src/ifcfg/parser.py
@@ -13,10 +13,14 @@ Log = minimal_logger(__name__)
 #: These will always be present for each device (even if they are None)
 DEVICE_PROPERTY_DEFAULTS = {
     'inet': None,
-    'inet4': "LIST",
+    'inet4': 'LIST',
     'ether': None,
-    'inet6': "LIST",  # Because lists are mutable
+    'inet6': 'LIST',  # Because lists are mutable
     'netmask': None,
+    'netmasks': 'LIST',
+    'broadcast': None,
+    'broadcasts': 'LIST',
+    'prefixlens': 'LIST',    
 }
 
 
@@ -42,13 +46,10 @@ class Parser(object):
     def parse(self, ifconfig=None):  # noqa: max-complexity=12
         """
         Parse ifconfig output into self._interfaces.
-
         Optional Arguments:
-
             ifconfig
                 The data (stdout) from the ifconfig command.  Default is to
                 call exec_cmd(self.get_command()).
-
         """
         if not ifconfig:
             ifconfig, errors, return_code = exec_cmd(self.get_command())
@@ -103,6 +104,16 @@ class Parser(object):
             if len(device_dict['inet4']) > 0:
                 device_dict['inet'] = device_dict['inet4'][0]
 
+        # Copy the first 'netmasks' mask to 'netmask' for backwards compatibility
+        for device, device_dict in self._interfaces.items():
+            if len(device_dict['netmasks']) > 0:
+                device_dict['netmask'] = device_dict['netmasks'][0]
+
+        # Copy the first 'broadcast' ip address to 'broadcast' for backwards compatibility
+        for device, device_dict in self._interfaces.items():
+            if len(device_dict['broadcasts']) > 0:
+                device_dict['broadcast'] = device_dict['broadcasts'][0]
+
         # fix it up
         self._interfaces = self.alter(self._interfaces)
 
@@ -110,14 +121,10 @@ class Parser(object):
         """
         Used to provide the ability to alter the interfaces dictionary before
         it is returned from self.parse().
-
         Required Arguments:
-
             interfaces
                 The interfaces dictionary.
-
         Returns: interfaces dict
-
         """
         # fixup some things
         for device, device_dict in interfaces.items():
@@ -198,7 +205,6 @@ class WindowsParser(Parser):
     def interfaces(self):
         """
         Returns the full interfaces dictionary.
-
         """
         return self._interfaces
 
@@ -236,10 +242,8 @@ class UnixParser(Parser):
     def get_patterns(cls):
         return [
             r'(?P<device>^[-a-zA-Z0-9:\.]+): flags=(?P<flags>.*) mtu (?P<mtu>\d+)',
-            r'.*inet\s+(?P<inet4>[\d\.]+).*',
-            r'.*inet6\s+(?P<inet6>[\d\:abcdef]+).*',
-            r'.*broadcast (?P<broadcast>[^\s]*).*',
-            r'.*netmask (?P<netmask>[^\s]*).*',
+            r'.*inet\s+(?P<inet4>[\d\.]+)((\s+netmask\s)|\/)(?P<netmasks>[\w.]+)(\s+(brd|broadcast)\s(?P<broadcasts>[^\s]*))?.*',
+            r'.*inet6\s+(?P<inet6>[\d\:abcdef]+)(%\w+)?((\s+prefixlen\s+)|\/)(?P<prefixlens>\d+)',
             r'.*ether (?P<ether>[^\s]*).*',
         ]
 
@@ -247,7 +251,6 @@ class UnixParser(Parser):
     def interfaces(self):
         """
         Returns the full interfaces dictionary.
-
         """
         return self._interfaces
 
@@ -286,12 +289,10 @@ class LinuxParser(UnixParser):
         return super(LinuxParser, cls).get_patterns() + [
             r'(?P<device>^[a-zA-Z0-9:_\-\.]+)(.*)Link encap:(.*).*',
             r'(.*)Link encap:(.*)(HWaddr )(?P<ether>[^\s]*).*',
-            r'.*(inet addr:\s*)(?P<inet4>[^\s]+).*',
-            r'.*(inet6 addr:\s*)(?P<inet6>[^\s\/]+)',
+            r'.*(inet addr:\s*)(?P<inet4>[^\s]+)\s+Bcast:(?P<broadcast>[^\s]*)\s+Mask:(?P<netmask>[^\s]*).*',
+            r'.*(inet6 addr:\s*)(?P<inet6>[^\s\/]+)\/(?P<prefixlen>\d+)',
             r'.*(MTU:\s*)(?P<mtu>\d+)',
             r'.*(P-t-P:)(?P<ptp>[^\s]*).*',
-            r'.*(Bcast:)(?P<broadcast>[^\s]*).*',
-            r'.*(Mask:)(?P<netmask>[^\s]*).*',
             r'.*(RX bytes:)(?P<rxbytes>\d+).*',
             r'.*(TX bytes:)(?P<txbytes>\d+).*',
         ]
@@ -368,6 +369,8 @@ class MacOSXParser(UnixParser):
         for device, device_dict in interfaces.items():
             if device_dict['netmask'] is not None:
                 interfaces[device]['netmask'] = hex2dotted(device_dict['netmask'])
+            if device_dict['netmasks'] is not None:
+                interfaces[device]['netmasks'] = [hex2dotted(mask) for mask in device_dict['netmasks']]
         return interfaces
 
     def _default_interface(self, route_output=None):

--- a/src/ifcfg/parser.py
+++ b/src/ifcfg/parser.py
@@ -130,7 +130,7 @@ class Parser(object):
         for device, device_dict in interfaces.items():
             if len(device_dict['inet4']) > 0:
                 device_dict['inet'] = device_dict['inet4'][0]
-            if 'inet' in device_dict and not device_dict['inet'] is None:
+            if 'inet' in device_dict and device_dict['inet'] is not None:
                 try:
                     host = socket.gethostbyaddr(device_dict['inet'])[0]
                     interfaces[device]['hostname'] = host

--- a/src/ifcfg/tools.py
+++ b/src/ifcfg/tools.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 import locale
 import logging
 import os
+import socket
+import struct
 from subprocess import PIPE, Popen
 
 system_encoding = locale.getpreferredencoding()
@@ -42,10 +44,4 @@ def exec_cmd(cmd_args):
     return (stdout, stderr, proc.returncode)
 
 def hex2dotted(hex_num):
-    num = hex_num.split('x')[1]
-    w = int(num[0:2], 16)
-    x = int(num[2:4], 16)
-    y = int(num[4:6], 16)
-    z = int(num[6:8], 16)
-
-    return "%d.%d.%d.%d" % (w, x, y, z)
+    return socket.inet_ntoa(struct.pack('>L',int(hex_num, base=0)))

--- a/tests/ifconfig_tests.py
+++ b/tests/ifconfig_tests.py
@@ -98,6 +98,8 @@ class IfcfgTestCase(IfcfgTestCase):
         eq_(interfaces['en0']['inet'], '192.168.0.1')
         eq_(interfaces['en0']['broadcast'], '192.168.0.255')
         eq_(interfaces['en0']['netmask'], '255.255.255.0')
+        eq_(interfaces['lo0']['netmasks'], ['255.0.0.0'])
+        eq_(interfaces['lo0']['prefixlens'], ['64', '128'])
 
     def test_macosx2(self):
         ifcfg.distro = 'MacOSX'

--- a/tests/ifconfig_tests.py
+++ b/tests/ifconfig_tests.py
@@ -110,6 +110,7 @@ class IfcfgTestCase(IfcfgTestCase):
         eq_(interfaces['lo0']['inet'], '127.0.0.1')
         eq_(interfaces['lo0']['inet4'], ['127.0.0.1', '127.0.1.99'])
         eq_(interfaces['lo0']['netmask'], '255.0.0.0')
+        eq_(interfaces['lo0']['netmasks'], ['255.0.0.0', '255.0.0.0'])
 
     def test_default_interface(self):
         ifcfg.distro = 'Linux'

--- a/tests/ifconfig_tests.py
+++ b/tests/ifconfig_tests.py
@@ -96,6 +96,7 @@ class IfcfgTestCase(IfcfgTestCase):
         self.assertEqual(len(interfaces.keys()), 2)
         eq_(interfaces['en0']['ether'], '1a:2b:3c:4d:5e:6f')
         eq_(interfaces['en0']['inet'], '192.168.0.1')
+        eq_(interfaces['en0']['broadcasts'], ['192.168.0.255'])
         eq_(interfaces['en0']['broadcast'], '192.168.0.255')
         eq_(interfaces['en0']['netmask'], '255.255.255.0')
         eq_(interfaces['lo0']['netmasks'], ['255.0.0.0'])

--- a/tests/tools_tests.py
+++ b/tests/tools_tests.py
@@ -20,7 +20,11 @@ class IfcfgToolsTestCase(unittest.TestCase):
         os.environ['IFCFG_DEBUG'] = '0'
 
     def test_command(self):
-        output, __, __ = exec_cmd("echo -n 'this is a test'")
+        if sys.platform == "darwin":
+            cmd = "/bin/echo -n 'this is a test'"
+        else:
+            cmd = "echo -n 'this is a test'"
+        output, __, __ = exec_cmd(cmd)
         self.assertEqual(output, "this is a test")
 
 


### PR DESCRIPTION
This adds `netmasks`, `broadcasts`, and `prefixlens` attributes as lists. For
backwards compatibility, copy the first item in `netmasks` and `broadcasts` to
`netmask` and `broadcast` respectively.

Also:
* a minor tweak to `tools_test.py`, which fails when run on macOS. (I believe this is likely due to the ancient version of `bash` that `/bin/sh` is.)
* update `hex2dotted` to use `struct`/`socket` to convert from hex to dotted quad
