### PR TITLE
Handle Linux hosts with multiple ipv6 prefix lengths

### DIFF
--- a/src/ifcfg/parser.py
+++ b/src/ifcfg/parser.py
@@ -20,7 +20,7 @@ DEVICE_PROPERTY_DEFAULTS = {
     'netmasks': 'LIST',
     'broadcast': None,
     'broadcasts': 'LIST',
-    'prefixlens': 'LIST',    
+    'prefixlens': 'LIST',
 }
 
 
@@ -289,8 +289,8 @@ class LinuxParser(UnixParser):
         return super(LinuxParser, cls).get_patterns() + [
             r'(?P<device>^[a-zA-Z0-9:_\-\.]+)(.*)Link encap:(.*).*',
             r'(.*)Link encap:(.*)(HWaddr )(?P<ether>[^\s]*).*',
-            r'.*(inet addr:\s*)(?P<inet4>[^\s]+)\s+Bcast:(?P<broadcast>[^\s]*)\s+Mask:(?P<netmask>[^\s]*).*',
-            r'.*(inet6 addr:\s*)(?P<inet6>[^\s\/]+)\/(?P<prefixlen>\d+)',
+            r'.*(inet addr:\s*)(?P<inet4>[^\s]+)\s+Bcast:(?P<broadcasts>[^\s]*)\s+Mask:(?P<netmasks>[^\s]*).*',
+            r'.*(inet6 addr:\s*)(?P<inet6>[^\s\/]+)\/(?P<prefixlens>\d+)',
             r'.*(MTU:\s*)(?P<mtu>\d+)',
             r'.*(P-t-P:)(?P<ptp>[^\s]*).*',
             r'.*(RX bytes:)(?P<rxbytes>\d+).*',
@@ -323,8 +323,8 @@ class UnixIPParser(UnixParser):
             r'.*(inet\s)(?P<inet4>[\d\.]+)',
             r'.*(inet6 )(?P<inet6>[^/]*).*',
             r'.*(ether )(?P<ether>[^\s]*).*',
-            r'.*inet\s.*(brd )(?P<broadcast>[^\s]*).*',
-            r'.*(inet )[^/]+(?P<netmask>[/][0-9]+).*',
+            r'.*inet\s.*(brd )(?P<broadcasts>[^\s]*).*',
+            r'.*(inet )[^/]+(?P<netmasks>[/][0-9]+).*',
         ]
 
     def _default_interface(self, route_output=None):

--- a/tests/ifconfig_out.py
+++ b/tests/ifconfig_out.py
@@ -284,3 +284,19 @@ Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
 169.254.0.0     0.0.0.0         255.255.0.0     U     1000   0        0 eth0
 192.168.1.0     0.0.0.0         255.255.255.0   U     600    0        0 eth0
 """
+
+
+LINUX_IPV6 = """
+lo        Link encap:Local Loopback  
+          inet6 addr: 2002:afb:afb::/128 Scope:Global
+          inet6 addr: ::1/128 Scope:Host
+          inet6 addr: fd14:988a:50ee:10c::/64 Scope:Global
+          inet6 addr: ::2/128 Scope:Compat
+          UP LOOPBACK RUNNING MULTICAST  MTU:65536  Metric:1
+          RX packets:2768145 errors:0 dropped:0 overruns:0 frame:0
+          TX packets:2768145 errors:0 dropped:0 overruns:0 carrier:0
+          collisions:0 txqueuelen:1000 
+          RX bytes:4642165574 (4.6 GB)  TX bytes:4642165574 (4.6 GB)
+
+
+"""

--- a/tests/ifconfig_tests.py
+++ b/tests/ifconfig_tests.py
@@ -121,3 +121,11 @@ class IfcfgTestCase(IfcfgTestCase):
             ifconfig=ifconfig_out.LINUX3, route_output=route_output
         )
         ok_(res)
+
+    def test_linux_ipv6(self):
+        ifcfg.distro = 'Linux'
+        ifcfg.Parser = LinuxParser
+        parser = ifcfg.get_parser(ifconfig=ifconfig_out.LINUX_IPV6)
+        interfaces = parser.interfaces
+        self.assertEqual(len(interfaces.keys()), 1)
+        eq_(interfaces['lo']['prefixlens'], ['128', '128', '64', '128'])


### PR DESCRIPTION
Use the correct regex named group identifiers: `prefixlen`->`prefixlens`,
`broadcast`->`broadcasts`, `netmask`->`netmasks`