### PR TITLE
Add support for underscore in UnixParser interface name (similar to LinuxParser)

### DIFF
--- a/src/ifcfg/parser.py
+++ b/src/ifcfg/parser.py
@@ -241,7 +241,7 @@ class UnixParser(Parser):
     @classmethod
     def get_patterns(cls):
         return [
-            r'(?P<device>^[-a-zA-Z0-9:\.]+): flags=(?P<flags>.*) mtu (?P<mtu>\d+)',
+            r'(?P<device>^[-a-zA-Z0-9:_\.]+): flags=(?P<flags>.*) mtu (?P<mtu>\d+)',
             r'.*inet\s+(?P<inet4>[\d\.]+)(\s+-->\s+(?P<_inet4>[\d\.]+))?((\s+netmask\s)|\/)(?P<netmasks>[\w.]+)((\s+(brd|broadcast)\s(?P<broadcasts>[^\s]*))?.*)?',
             r'.*inet6\s+(?P<inet6>[\d\:abcdef]+)(%\w+)?((\s+prefixlen\s+)|\/)(?P<prefixlens>\d+)',
             r'.*ether (?P<ether>[^\s]*).*',


### PR DESCRIPTION
This PR adds support for underscores in the interface name when UnixParser is invoked. This addresses issue #73.